### PR TITLE
call libtoolize as glibtoolize; use dylib shared library suffix

### DIFF
--- a/js/bld.sh
+++ b/js/bld.sh
@@ -1,9 +1,22 @@
 #!/bin/bash
 
+case `uname` in
+  Darwin*)
+  libtoolize="glibtoolize"
+  so="dylib"
+  ;;
+
+  *)
+  libtoolize="libtoolize"
+  so="so"
+  ;;
+esac
+
+
 # generate configure file
 pushd .
 cd ..
-libtoolize --force
+${libtoolize} --force
 aclocal
 automake --force-missing --add-missing
 autoconf -i
@@ -16,6 +29,6 @@ mkdir -p build
 cd build
 emconfigure ../../configure --prefix=`pwd`
 emmake make install
-cp lib/libopencore-amrnb.so ../amrnb.bc
+cp lib/libopencore-amrnb.${so} ../amrnb.bc
 popd
 


### PR DESCRIPTION
This gets amrnb.js building on Mac. There are still some warnings, a bunch of which look like this:

> amrnb/Makefile.am:58: warning: source file '$(DEC_SRC_DIR)/amrdecode.cpp' is in a subdirectory,
> amrnb/Makefile.am:58: but option 'subdir-objects' is disabled

And then there are these three:

> WARNING  root: emcc: cannot find library "m"
> WARNING  root: emcc: cannot find library "c"
> WARNING  root: Dynamic libraries (.so, .dylib, .dll) are currently not supported by Emscripten. For build system emulation purposes, Emscripten will now generate a static library file (.bc) with the suffix '.dylib'. For best practices, please adapt your build system to directly generate a static LLVM bitcode library by setting the output suffix to '.bc.')

So there may be more work to do here. Nevertheless, the build succeeds.

The two changes are:
1. Call _libtoolize_ as _glibtoolize_ on Mac, per [this StackOverflow question](http://stackoverflow.com/questions/15448582/installed-libtool-but-libtoolize-not-found), which says, "You typically need to use glibtool and glibtoolize, since libtool already exists on OS X as a binary tool for creating Mach-O dynamic libraries."
2. Change the shared library suffix from _so_ to _dylib_ on Mac.
